### PR TITLE
Updated sequencer repair integration test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,5 +14,5 @@ jobs:
     - stage: test
       name: "repairnator-integration-test"
       install: ./.travis/travis-before.sh
-      script: ./.travis/travis-run.sh
+      script: travis_wait 40 ./.travis/travis-run.sh
 

--- a/.travis/travis-before.sh
+++ b/.travis/travis-before.sh
@@ -1,5 +1,5 @@
 docker pull repairnator/pipeline
-docker pull repairnator/sequencer:1.0
+docker pull repairnator/sequencer:2.0
 docker pull antonw/activemq-jmx:latest
 docker run -d --net=host antonw/activemq-jmx:latest
 docker ps -a

--- a/pom.xml
+++ b/pom.xml
@@ -104,6 +104,14 @@
           <artifactId>maven-project-info-reports-plugin</artifactId>
           <version>3.0.0</version>
         </plugin>
-      </plugins>
+        <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <configuration>
+                <source>8</source>
+                <target>8</target>
+            </configuration>
+        </plugin>
+    </plugins>
   </build>
 </project>

--- a/src/test/java/fr/inria/repairnator/SequencerRepairTest.java
+++ b/src/test/java/fr/inria/repairnator/SequencerRepairTest.java
@@ -3,24 +3,23 @@ package fr.inria.repairnator;
 import ch.qos.logback.classic.Level;
 import fr.inria.jtravis.entities.Build;
 import fr.inria.spirals.repairnator.BuildToBeInspected;
-import fr.inria.spirals.repairnator.process.step.paths.ComputeTestDir;
-import fr.inria.spirals.repairnator.process.step.repair.sequencer.SequencerRepair;
-import fr.inria.spirals.repairnator.utils.Utils;
 import fr.inria.spirals.repairnator.config.RepairnatorConfig;
-import fr.inria.spirals.repairnator.process.files.FileHelper;
 import fr.inria.spirals.repairnator.process.inspectors.ProjectInspector;
 import fr.inria.spirals.repairnator.process.inspectors.RepairPatch;
-import fr.inria.spirals.repairnator.process.step.StepStatus;
+import fr.inria.spirals.repairnator.process.step.AbstractStep;
 import fr.inria.spirals.repairnator.process.step.CloneRepository;
+import fr.inria.spirals.repairnator.process.step.StepStatus;
 import fr.inria.spirals.repairnator.process.step.TestProject;
 import fr.inria.spirals.repairnator.process.step.checkoutrepository.CheckoutBuggyBuild;
 import fr.inria.spirals.repairnator.process.step.gatherinfo.BuildShouldFail;
 import fr.inria.spirals.repairnator.process.step.gatherinfo.GatherTestInformation;
 import fr.inria.spirals.repairnator.process.step.paths.ComputeClasspath;
 import fr.inria.spirals.repairnator.process.step.paths.ComputeSourceDir;
+import fr.inria.spirals.repairnator.process.step.paths.ComputeTestDir;
+import fr.inria.spirals.repairnator.process.step.repair.sequencer.SequencerRepair;
 import fr.inria.spirals.repairnator.serializer.AbstractDataSerializer;
 import fr.inria.spirals.repairnator.states.ScannedBuildStatus;
-import fr.inria.spirals.repairnator.process.step.AbstractStep;
+import fr.inria.spirals.repairnator.utils.Utils;
 import org.hamcrest.core.Is;
 import org.hamcrest.core.IsNull;
 import org.junit.After;
@@ -30,7 +29,9 @@ import org.junit.Test;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
-import java.util.*;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
@@ -56,7 +57,7 @@ public class SequencerRepairTest {
 
     @Test
     public void testSequencerRepair() throws IOException {
-        long buildId = 252712792; // surli/failingProject build
+        long buildId = 703887431; // javierron/failingProject build
         Build build = this.checkBuildAndReturn(buildId, false);
 
         tmpDir = Files.createTempDirectory("test_sequencer_repair").toFile();
@@ -93,7 +94,7 @@ public class SequencerRepairTest {
         assertThat(finalStatus, is("PATCHED"));
 
         List<RepairPatch> allPatches = inspector.getJobStatus().getAllPatches();
-        assertThat(allPatches.size(), is(248));
+        assertThat(allPatches.size(), is(4));
         assertThat(inspector.getJobStatus().getToolDiagnostic().get(sequencerRepair.getRepairToolName()), notNullValue());
     }
 


### PR DESCRIPTION
The SequencerRepair test is now performed on a very simple [failing project](https://github.com/javierron/failingProject/tree/e182ccb9ef41b5adab602ed12bfc71b744ff0241) (one test case, one line bug).

The patches produced by the new version of `repairnator/sequencer` are tested by performing `mvn test` after applying each patch.

Only the patches that produce a successful `mvn test` run are returned.

Closes #4 

Signed-off-by: Javier Ron <javierron90@gmail.com>